### PR TITLE
API URLs are not async, thus should not be under 'inf'

### DIFF
--- a/vlab_quota/libs/views/healthcheck.py
+++ b/vlab_quota/libs/views/healthcheck.py
@@ -14,7 +14,7 @@ class HealthView(FlaskView):
     """
     Simple end point to test if the service is alive
     """
-    route_base = '/api/1/inf/quota/healthcheck'
+    route_base = '/api/1/quota/healthcheck'
     trailing_slash = False
 
     def get(self):

--- a/vlab_quota/libs/views/quota.py
+++ b/vlab_quota/libs/views/quota.py
@@ -11,7 +11,7 @@ logger = get_logger(__name__, loglevel=const.QUOTA_LOG_LEVEL)
 
 class QuotaView(BaseView):
     """API end point for checking on quota violations"""
-    route_base = '/api/1/inf/quota'
+    route_base = '/api/1/quota'
     GET_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
                   "description": "Return quota information"
                  }


### PR DESCRIPTION
This API is not async like everything else under `/api/1/inf/` (like `onefs` and `insightiq`). 
To make the vLab API to be more consistent, this PR pulls `quota` into it's _own thing_.