### PR TITLE
Lib for sending notifications completed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include vlab_quota/app.ini
 include README.rst
+recursive-include vlab_quota/ *.html

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -20,7 +20,15 @@ class TestConsts(unittest.TestCase):
                     'INF_VCENTER_USER',
                     'QUOTA_LOG_LEVEL',
                     'VLAB_URL',
-                    'VLAB_VERIFY_TOKEN']
+                    'VLAB_VERIFY_TOKEN',
+                    'QUOTA_EMAIL_SSL',
+                    'QUOTA_EMAIL_SSL_VERIFY',
+                    'QUOTA_EMAIL_FROM_DOMAIN',
+                    'QUOTA_EMAIL_SERVER',
+                    'QUOTA_EMAIL_PASSWORD',
+                    'QUOTA_EMAIL_USERNAME',
+                    'QUOTA_EMAIL_BCC',
+                    'VLAB_QUOTA_LIMIT']
 
         # set() avoids false positives due to ordering
         self.assertEqual(set(found), set(expected))

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,263 @@
+# -*- coding: UTF-8 -*-
+"""A suite of unit tests for the ``notify.py`` module"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from vlab_quota.libs import notify
+
+
+@patch.object(notify, 'log') # cuts down on SPAM output
+class TestGetSslContext(unittest.TestCase):
+    """A suite of test cases for the ``_get_ssl_context`` function"""
+    def test_ssl_context_type(self, fake_log):
+        """``_get_ssl_context`` returns the expected object type"""
+        context = notify._get_ssl_context()
+
+        self.assertTrue(isinstance(context, notify.ssl.SSLContext))
+
+    @patch.object(notify, 'const')
+    def test_no_verify(self, fake_const, fake_log):
+        """``_get_ssl_context`` does not verify the host cert when ``const.QUOTA_EMAIL_SSL_VERIFY`` is False"""
+        fake_const.QUOTA_EMAIL_SSL_VERIFY = False
+
+        context = notify._get_ssl_context()
+
+        self.assertEqual(context.verify_mode, notify.ssl.CERT_NONE)
+
+    @patch.object(notify, 'const')
+    def test_verify_cert(self, fake_const, fake_log):
+        """``_get_ssl_context`` will verify the host cert when ``const.QUOTA_EMAIL_SSL_VERIFY`` is not False"""
+        fake_const.QUOTA_EMAIL_SSL_VERIFY = 'anything'
+
+        context = notify._get_ssl_context()
+
+        self.assertEqual(context.verify_mode, notify.ssl.CERT_REQUIRED)
+
+
+class TestGenerateWarning(unittest.TestCase):
+    """A suite of test cases for the ``_generate_warning`` function"""
+    TEMPLATE = """
+        <html>
+          <body style="font-family:Helvetica;">
+           <div style="background:blue">
+             <h1 style="color:white;margin-left:5px">vLab</h1>
+           </div>
+           <h2 style="color:red;font-weight:bold">Quota Violation</h2>
+           <p>You currently have {{ vm_quota }} VMs.<br>
+              You are allowed to have {{ vm_count }} VMs.<br><br>
+
+              If you do not <b>delete {{ vm_delta }} VMs by {{ exp_date }}</b>, vLab will randomly choose which VMs <br>
+              to delete on that date.<br><br>
+
+              You have been warned.
+           </p>
+          </body>
+        </html>
+    """
+
+    @patch.object(notify, 'open')
+    def test_generate_warning(self, fake_open):
+        """``_generate_warning`` returns a string"""
+        fake_open.return_value.__enter__.return_value.read.return_value = self.TEMPLATE
+        message = notify._generate_warning(9001, 1234)
+
+        self.assertTrue(isinstance(message, str))
+
+
+class TestGenerateFollowUp(unittest.TestCase):
+    """A suite of test cases for the ``_generate_follow_up`` function"""
+    TEMPLATE = """
+        <html>
+          <body style="font-family:Helvetica;">
+           <div style="background:blue">
+             <h1 style="color:white;margin-left:5px">vLab</h1>
+           </div>
+           <h2 style="color:red;font-weight:bold">Quota Violation</h2>
+           <p>On {{ date }} vLab deleted the following VMs:</p>
+           <ul>
+            {% for vm in vms %}
+            <li>{{ vm }}</li>
+            {% endfor %}
+           </ul>
+           <p>These VMs were randomly choosen, and were deleted due to the soft-quota
+            grace period expiring.
+           </p>
+          </body>
+        </html>
+    """
+    @patch.object(notify, 'open')
+    def test_generate_follow_up_html(self, fake_open):
+        """``_generate_follow_up`` returns a string"""
+        fake_open.return_value.__enter__.return_value.read.return_value = self.TEMPLATE
+        message = notify._generate_follow_up(1234, ['vmFoo', 'vmBar'])
+
+        self.assertTrue(isinstance(message, str))
+
+
+class TestMakeEmail(unittest.TestCase):
+    """A suite of test cases for the ``_make_email`` function"""
+
+    def test_return_type(self):
+        """``_make_email`` Returns a string that is the full email to send"""
+        mail = notify._make_email('bob@vlab.local', 'some email body')
+
+        self.assertTrue(isinstance(mail, str))
+
+
+@patch.object(notify, 'const')
+@patch.object(notify, 'log')
+class TestSendEmail(unittest.TestCase):
+    """A suite of test cases for the ``_send_email`` function"""
+
+    @patch.object(notify.smtplib, 'SMTP_SSL')
+    def test_ssl(self, fake_SMTP_SSL, fake_log, fake_const):
+        """``_send_email`` can send emails via SSL"""
+        fake_const.QUOTA_EMAIL_SSL = True
+        fake_mailer = MagicMock()
+        fake_mailer.sendmail.return_value = None
+        fake_SMTP_SSL.return_value = fake_mailer
+
+        notify._send_email('sally@vlab.local', 'some email')
+
+        self.assertTrue(fake_mailer.sendmail.called)
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_cleartext(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` can send emails via clear text"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_mailer = MagicMock()
+        fake_mailer.sendmail.return_value = None
+        fake_SMTP.return_value = fake_mailer
+
+        notify._send_email('sally@vlab.local', 'some email')
+
+        self.assertTrue(fake_mailer.sendmail.called)
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_login(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` Attempts to login when username and password are defined"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_mailer = MagicMock()
+        fake_mailer.sendmail.return_value = None
+        fake_SMTP.return_value = fake_mailer
+
+        notify._send_email('sally@vlab.local', 'some email')
+        # const.QUOTA_EMAIL_USERNAME and const.QUOTA_EMAIL_PASSWORD are implictly
+        # true because of the mock/patch
+        self.assertTrue(fake_mailer.login.called)
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_login_no_user(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` does not attempt to login when no username is defined"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_const.QUOTA_EMAIL_USERNAME = ''
+        fake_mailer = MagicMock()
+        fake_mailer.sendmail.return_value = None
+        fake_SMTP.return_value = fake_mailer
+
+        notify._send_email('sally@vlab.local', 'some email')
+
+        self.assertFalse(fake_mailer.login.called)
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_login_no_password(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` does not attempt to login when no password is defined"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_const.QUOTA_EMAIL_PASSWORD = ''
+        fake_mailer = MagicMock()
+        fake_mailer.sendmail.return_value = None
+        fake_SMTP.return_value = fake_mailer
+
+        notify._send_email('sally@vlab.local', 'some email')
+
+        self.assertFalse(fake_mailer.login.called)
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_bcc(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` will BCC an email if it's defined"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_const.QUOTA_EMAIL_BCC = 'jill@vlab.local'
+        fake_mailer = MagicMock()
+        fake_mailer.sendmail.return_value = None
+        fake_SMTP.return_value = fake_mailer
+
+        notify._send_email('sally@vlab.local', 'some email')
+        the_args, _ = fake_mailer.sendmail.call_args
+        sent_to = the_args[1]
+        expected = ['jill@vlab.local', 'sally@vlab.local']
+        # set() avoids false positive due to ordering
+        self.assertEqual(set(sent_to), set(expected))
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_no_bcc(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` will not BCC an email if it is not defined"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_const.QUOTA_EMAIL_BCC = ''
+        fake_mailer = MagicMock()
+        fake_mailer.sendmail.return_value = None
+        fake_SMTP.return_value = fake_mailer
+
+        notify._send_email('sally@vlab.local', 'some email')
+        the_args, _ = fake_mailer.sendmail.call_args
+        sent_to = the_args[1]
+        expected = ['sally@vlab.local']
+
+        self.assertEqual(sent_to, expected)
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_always_closes(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` closes the server connection, even upon error"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_mailer = MagicMock()
+        fake_SMTP.return_value = fake_mailer
+        fake_mailer.sendmail.side_effect = [RuntimeError('testing')]
+
+        try:
+            notify._send_email('sally@vlab.local', 'some email')
+        except RuntimeError:
+            pass
+
+        self.assertTrue(fake_mailer.close.called)
+
+    @patch.object(notify.smtplib, 'SMTP')
+    def test_raises_erorrs(self, fake_SMTP, fake_log, fake_const):
+        """``_send_email`` Raises NotifyError if sending email fails"""
+        fake_const.QUOTA_EMAIL_SSL = False
+        fake_mailer = MagicMock()
+        fake_SMTP.return_value = fake_mailer
+        fake_mailer.sendmail.return_value = {'salldy@vlab.local', (500, "no such user")}
+
+        with self.assertRaises(notify.NotifyError):
+            notify._send_email('salldy@vlab.local', 'asdfwed')
+
+
+class TestSendWarning(unittest.TestCase):
+    """A suite of test cases for the ``send_warning`` function"""
+    @patch.object(notify, '_generate_warning')
+    @patch.object(notify, '_make_email')
+    @patch.object(notify, '_send_email')
+    def test_send_warning(self, fake_generate_warning, fake_make_email, fake_send_email):
+        """``send_warning`` constructs the correct email, and sends it"""
+        notify.send_warning('bob@vlab.local', 45, 123456789)
+
+        self.assertTrue(fake_generate_warning.called)
+        self.assertTrue(fake_make_email.called)
+        self.assertTrue(fake_send_email.called)
+
+
+class TestSendFollowUp(unittest.TestCase):
+    """A suite of test cases for the ``send_warning`` function"""
+    @patch.object(notify, '_generate_follow_up')
+    @patch.object(notify, '_make_email')
+    @patch.object(notify, '_send_email')
+    def test_send_follow_up(self, fake_generate_follow_up, fake_make_email, fake_send_email):
+        """``send_follow_up`` constructs the correct email, and sends it"""
+        notify.send_follow_up('bob@vlab.local', 45, 123456789)
+
+        self.assertTrue(fake_generate_follow_up.called)
+        self.assertTrue(fake_make_email.called)
+        self.assertTrue(fake_send_email.called)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vlab_quota/libs/constants.py
+++ b/vlab_quota/libs/constants.py
@@ -15,6 +15,14 @@ DEFINED = OrderedDict([
             ('DB_DATABASE_NAME', environ.get('DB_DATABASE_NAME', 'quota')),
             ('DB_HOST', environ.get('DB_HOST', 'quota-db')),
             ('VLAB_VERIFY_TOKEN', environ.get('VLAB_VERIFY_TOKEN', False)),
+            ('VLAB_QUOTA_LIMIT', int(environ.get('VLAB_QUOTA_LIMIT', 30))),
+            ('QUOTA_EMAIL_SERVER', environ.get('QUOTA_EMAIL_SERVER', 'localhost')),
+            ('QUOTA_EMAIL_FROM_DOMAIN', 'noreply@{}'.format(environ.get('QUOTA_EMAIL_FROM_DOMAIN', 'vlab.local'))),
+            ('QUOTA_EMAIL_BCC', environ.get('QUOTA_EMAIL_BCC', '')),
+            ('QUOTA_EMAIL_SSL', environ.get('QUOTA_EMAIL_SSL', False)),
+            ('QUOTA_EMAIL_SSL_VERIFY', environ.get('QUOTA_EMAIL_SSL_VERIFY', False)),
+            ('QUOTA_EMAIL_USERNAME', environ.get('QUOTA_EMAIL_USERNAME', '')),
+            ('QUOTA_EMAIL_PASSWORD', environ.get('QUOTA_EMAIL_PASSWORD', '')),
           ])
 
 Constants = namedtuple('Constants', list(DEFINED.keys()))

--- a/vlab_quota/libs/delete_followup.html
+++ b/vlab_quota/libs/delete_followup.html
@@ -1,0 +1,17 @@
+<html>
+  <body style="font-family:Helvetica;">
+   <div style="background:blue">
+     <h1 style="color:white;margin-left:5px">vLab</h1>
+   </div>
+   <h2 style="color:red;font-weight:bold">Quota Violation</h2>
+   <p>On {{ date }} vLab deleted the following VMs:</p>
+   <ul>
+    {% for vm in vms %}
+    <li>{{ vm }}</li>
+    {% endfor %}
+   </ul>
+   <p>These VMs were randomly choosen, and were deleted due to the soft-quota
+    grace period expiring.
+   </p>
+  </body>
+</html>

--- a/vlab_quota/libs/notify.py
+++ b/vlab_quota/libs/notify.py
@@ -1,0 +1,163 @@
+# -*- coding: UTF-8 -*-
+"""For sending email notifications to users about quota violations"""
+import ssl
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from datetime import datetime, timezone
+
+import jinja2
+from vlab_api_common.std_logger import get_logger
+
+from vlab_quota.libs import const
+
+log = get_logger(name=__name__, loglevel=const.QUOTA_LOG_LEVEL)
+
+
+
+class NotifyError(Exception):
+    def __init__(self, message, send_errors):
+        super(NotifyError, self).__init__(message)
+        self.send_errors = send_errors
+
+
+def _get_ssl_context():
+    """Defines what versions & ciphers to use when sending an email to the server
+
+    :Returns: ssl.SSLContext
+    """
+    if const.QUOTA_EMAIL_SSL_VERIFY is False:
+        log.debug('Not verifying SSL cert of SMTP server')
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        context.verify_mode = ssl.CERT_NONE
+    else:
+        context = ssl.create_default_context()
+    return context
+
+
+def _generate_warning(vm_count, exp_date, template='violation_warning.html'):
+    """Create the HTML email body to warn users about a quota violation.
+
+    :Returns: String
+
+    :param vm_count: The number of VMs a user has.
+    :type vm_count: Integer
+
+    :param exp_date: When the soft quota grace period will expire (EPOCH).
+    :type exp_date: Integer
+    """
+    with open(template) as the_file:
+        template_data = the_file.read()
+    vm_delta = vm_count - const.VLAB_QUOTA_LIMIT
+    message = jinja2.Template(template_data).render(vm_quota=const.VLAB_QUOTA_LIMIT,
+                                                    vm_count=vm_count,
+                                                    vm_delta=vm_delta,
+                                                    exp_date=datetime.fromtimestamp(exp_date, timezone.utc))
+    return message
+
+
+def _generate_follow_up(the_date, vms, template='delete_followup.html'):
+    """Create the HTML email body stating what VMs were randomly deleted.
+
+    :Returns: String
+
+    :param the_date: The specific time when vLab randomly deleted a user's VM(s).
+    :type the_date: Integer
+
+    :param vms: The names of the VM(s) deleted.
+    :type vms: List
+    """
+    with open(template) as the_file:
+        template_data = the_file.read()
+    message = jinja2.Template(template_data).render(the_date=datetime.fromtimestamp(the_date, timezone.utc),
+                                                    vms=vms)
+    return message
+
+
+def _make_email(to, body):
+    """Construct the email
+
+    Returns: String
+
+    :param to: The email address of the recipient.
+    :type to: String
+
+    :param body: The HTML content of the email.
+    :type body: String
+    """
+    mail = MIMEMultipart('alternative')
+    mail['Subject'] = 'vLab Quota Violation'
+    mail['To'] = to
+    mail['From'] = const.QUOTA_EMAIL_FROM_DOMAIN
+    mail.attach(MIMEText(body, 'html'))
+    return mail.as_string()
+
+
+def _send_email(to, mail):
+    """Connect to the SMTP server and send an email.
+
+    :Returns: None
+
+    :Raises: NotifyError
+
+    :param to: The email address of the recipient.
+    :type to: String
+
+    :param mail: The constructed email to send
+    :type mail: String
+    """
+    if const.QUOTA_EMAIL_SSL:
+        log.debug('Sending email with SSL connection to server')
+        mailer = smtplib.SMTP_SSL(const.QUOTA_EMAIL_SERVER, context=_get_ssl_context())
+    else:
+        log.debug("Sending email via clear text")
+        mailer = smtplib.SMTP(const.QUOTA_EMAIL_SERVER)
+
+    if const.QUOTA_EMAIL_USERNAME and const.QUOTA_EMAIL_PASSWORD:
+        log.debug('Authenticating to SMTP server with user %s', const.QUOTA_EMAIL_USERNAME)
+        mailer.login(const.QUOTA_EMAIL_USERNAME, const.QUOTA_EMAIL_PASSWORD)
+    else:
+        log.debug('Username & Password not provided, assuming no auth needed')
+
+    if const.QUOTA_EMAIL_BCC:
+        log.debug("BCCing %s", const.QUOTA_EMAIL_BCC)
+        recipients = [to, const.QUOTA_EMAIL_BCC]
+    else:
+        recipients = [to]
+
+    errors = None
+    try:
+        errors = mailer.sendmail(const.QUOTA_EMAIL_FROM_DOMAIN, recipients, mail)
+    finally:
+        mailer.close()
+
+    if errors:
+        raise NotifyError('Failure sending all emails', errors)
+
+
+def send_warning(to, vm_count, exp_date):
+    """Email the user letting them know when their soft-quota grace period will
+    expire, and as a result, vLab will randomly delete VMs from their lab.
+
+    :Returns: None
+
+    :param to: The email address of the recipient.
+    :type to: String
+    """
+    body = _generate_warning(vm_count, exp_date)
+    mail = _make_email(to, body)
+    _send_email(to, mail)
+
+
+def send_follow_up(to, the_date, vms):
+    """Email the user about the VMs that were deleted due to the grace period
+    of their soft-quota expiring.
+
+    :Returns: None
+
+    :param to: The email address of the recipient.
+    :type to: String
+    """
+    body = _generate_follow_up(the_date, vms)
+    mail = _make_email(to, body)
+    _send_email(to, mail)

--- a/vlab_quota/libs/violation_warning.html
+++ b/vlab_quota/libs/violation_warning.html
@@ -1,0 +1,16 @@
+<html>
+  <body style="font-family:Helvetica;">
+   <div style="background:blue">
+     <h1 style="color:white;margin-left:5px">vLab</h1>
+   </div>
+   <h2 style="color:red;font-weight:bold">Quota Violation</h2>
+   <p>You currently have {{ vm_quota }} VMs.<br>
+      You are allowed to have {{ vm_count }} VMs.<br><br>
+
+      If you do not <b>delete {{ vm_delta }} VMs by {{ exp_date }}</b>, vLab will randomly choose which VMs <br>
+      to delete on that date.<br><br>
+
+      You have been warned.
+   </p>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a library module for sending notifications. It abstracts the logic for constructing and sending an email into two simple API calls:

- `send_warning`: For sending a notification of the exceeded soft quota, when the grace period expires, and the consequences of the grace period expiring.
- `send_follow_up`: If the grace period expires and vLab deletes a user's VMs, this notification tells them _what_ was deleted and when.
