### PR TITLE
user_info returns the violation date and the last notification date

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -82,16 +82,16 @@ class TestDatabase(unittest.TestCase):
         self.assertTrue(isinstance(result, list))
 
     def test_user_info(self):
-        """``user_info`` returns an integer"""
+        """``user_info`` returns a tuple"""
         fake_fetchall = MagicMock()
-        fake_fetchall.return_value = [(1234,)]
+        fake_fetchall.return_value = [(1234, 5678)]
         db = database.Database()
         db._cursor.fetchall = fake_fetchall
 
-        exceeded_quota_epoch = db.user_info('sally')
-        expected = 1234
+        info = db.user_info('sally')
+        expected = (1234, 5678)
 
-        self.assertEqual(exceeded_quota_epoch, expected)
+        self.assertEqual(info, expected)
 
     def test_user_info_no_violations(self):
         """``user_info`` returns zero when the user has no quota violations"""
@@ -101,7 +101,7 @@ class TestDatabase(unittest.TestCase):
         db._cursor.fetchall = fake_fetchall
 
         exceeded_quota_epoch = db.user_info('sally')
-        expected = 0
+        expected = (0, 0)
 
         self.assertEqual(exceeded_quota_epoch, expected)
 

--- a/tests/test_quota_view.py
+++ b/tests/test_quota_view.py
@@ -26,13 +26,14 @@ class TestQuotaView(unittest.TestCase):
         cls.app = app.test_client()
 
     @patch.object(quota, 'Database')
-    def test_foo(self, fake_Database):
+    def test_basic(self, fake_Database):
         """QuotaView - GET on /api/1/quota returns the expected JSON response"""
-        fake_Database.return_value.__enter__.return_value.user_info.return_value = 0
+        fake_Database.return_value.__enter__.return_value.user_info.return_value = (1234, 2345)
         resp = self.app.get('/api/1/quota',
                             headers={'X-Auth' : self.token})
-        expected = {'error': None, 'content': { 'exceeded_on': None }, 'params': {}}
+        expected = {'error': None, 'content': {'exceeded_on': 1234, 'last_notified': 2345}, 'params': {}}
 
+        self.assertEqual(resp.json, expected)
 
 
 if __name__ == '__main__':

--- a/vlab_quota/libs/database.py
+++ b/vlab_quota/libs/database.py
@@ -73,11 +73,11 @@ class Database:
         :param username: The name of the user
         :type username: String
         """
-        sql = """SELECT triggered FROM quota_violations WHERE username LIKE (%s);"""
+        sql = """SELECT triggered, last_notified FROM quota_violations WHERE username LIKE (%s);"""
         exceeded_on = self.execute(sql, (username,))
         if exceeded_on:
-            return exceeded_on[0][0] # because it's a list of tuples, i.e. [(12345,)]
-        return 0
+            return exceeded_on[0] # because it's a list of tuples, i.e. [(12345,)]
+        return (0, 0)
 
 
 class DatabaseError(Exception):

--- a/vlab_quota/libs/views/quota.py
+++ b/vlab_quota/libs/views/quota.py
@@ -22,8 +22,8 @@ class QuotaView(BaseView):
         """Obtain quota information"""
         username = kwargs['token']['username']
         with Database() as db:
-            exceeded_on = db.user_info(username)
-        resp_data = {'content': {'exceeded_on': exceeded_on}}
+            exceeded_on, last_notified = db.user_info(username)
+        resp_data = {'content': {'exceeded_on': exceeded_on, 'last_notified': last_notified}}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 200
         resp.headers.add('Link', '<{0}/api/1/inf/inventory>; rel=inventory'.format(const.VLAB_URL))


### PR DESCRIPTION
This PR updates the `user_info` method on the Database object to return both the last time a notification was sent about a quota violation, as well as the initial date when a violation was detected.

Before, this method would only return the initial date of the quota violation.

This change is to make the code for detecting and processing (still a work-in-progress) quota violations simpler.