### PR TITLE
Added more quota info to GET response on /api/1/quota

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-quotas",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2020.02.13',
+      version='2020.02.28',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_quotas' : ['app.ini']},

--- a/tests/test_quota_view.py
+++ b/tests/test_quota_view.py
@@ -31,7 +31,14 @@ class TestQuotaView(unittest.TestCase):
         fake_Database.return_value.__enter__.return_value.user_info.return_value = (1234, 2345)
         resp = self.app.get('/api/1/quota',
                             headers={'X-Auth' : self.token})
-        expected = {'error': None, 'content': {'exceeded_on': 1234, 'last_notified': 2345}, 'params': {}}
+        expected = {'error': None,
+                    'content': {
+                        'exceeded_on': 1234,
+                        'last_notified': 2345,
+                        'grace_period': quota.const.QUOTA_GRACE_PERIOD,
+                        'soft-limit': quota.const.VLAB_QUOTA_LIMIT,
+                        },
+                    'params': {}}
 
         self.assertEqual(resp.json, expected)
 

--- a/vlab_quota/libs/views/quota.py
+++ b/vlab_quota/libs/views/quota.py
@@ -23,7 +23,13 @@ class QuotaView(BaseView):
         username = kwargs['token']['username']
         with Database() as db:
             exceeded_on, last_notified = db.user_info(username)
-        resp_data = {'content': {'exceeded_on': exceeded_on, 'last_notified': last_notified}}
+        resp_data = {'content': {
+                        'exceeded_on': exceeded_on,
+                        'last_notified': last_notified,
+                        'grace_period': const.QUOTA_GRACE_PERIOD,
+                        'soft-limit': const.VLAB_QUOTA_LIMIT,
+                        }
+                    }
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 200
         resp.headers.add('Link', '<{0}/api/1/inf/inventory>; rel=inventory'.format(const.VLAB_URL))


### PR DESCRIPTION
While starting to incorporate some of the quota info for the CLI, I realized that returning the soft-limit and grace period along with violation information would be pretty handy! 😅 