### PR TITLE
More patches to come!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-quotas",
       author="Nicholas Willhite",
       author_email='willnx84@gmail.com',
-      version='2020.04.07',
+      version='2020.04.16',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_quotas' : ['app.ini']},

--- a/vlab_quota/worker.py
+++ b/vlab_quota/worker.py
@@ -35,6 +35,8 @@ def _grace_period_exceeded(violation_date):
     :param violation_date: The EPOCH timestamp when the user exceeded their VM quota.
     :type violation_date: Integer
     """
+    if violation_date is 0:
+        return False
     return int(time.time()) > (violation_date + const.QUOTA_GRACE_PERIOD)
 
 


### PR DESCRIPTION
This is the first of several likely patches. This specific one is... gnarly! The `Database.get_info` returns a violation date of zero if a user doesn't exist in the DB. This caused the `_grace_period_exceeded` check in the `worker.py` module to think the soft grace period had expired back in 1970. The result, it that the worker would just try to delete VMs, without warning 😅.

Nothing is actually getting deleted because of a 2nd bug, where the user's gateway is getting multiple client IPs in the HTTP header. This causes the gateway to reject the deletion of portmap rules, and as a result, the whole app crashes and then restarts. 